### PR TITLE
Allow explicit context to be passed in constructor

### DIFF
--- a/Core/Collections/ObjectModel/SynchronizedObservableCollection`1.cs
+++ b/Core/Collections/ObjectModel/SynchronizedObservableCollection`1.cs
@@ -34,6 +34,24 @@ namespace CCSWE.Collections.ObjectModel
                 _items.Add(item);
             }
         }
+        
+        public SynchronizedObservableCollection(SynchronizationContext context)
+        {
+            _context = context;
+        }
+
+        public SynchronizedObservableCollection(IEnumerable<T> collection, SynchronizationContext context): this(context)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection", "'collection' cannot be null");
+            }
+
+            foreach (var item in collection)
+            {
+                _items.Add(item);
+            }
+        }
         #endregion
 
         #region Private Fields


### PR DESCRIPTION
This allows a context (ex. DispatcherSynchronizationContext) to be passed from a thread without a 'SynchronizationContext.
